### PR TITLE
add missing * in gitignore for *.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,4 +242,4 @@ apikeys.py
 .vscode
 
 # Ignore Python Cache
-.pyc
+*.pyc


### PR DESCRIPTION
Missing an \* in .gitignore
